### PR TITLE
Set capacity for dynamic collections

### DIFF
--- a/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation/DynamicCollections/CSharpSetCollectionCapacity.cs
+++ b/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation/DynamicCollections/CSharpSetCollectionCapacity.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Robotmaster.CollectionRecommendation.DynamicCollections
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CSharpSetCollectionCapacity : DiagnosticAnalyzer
+    {
+        public const string SetCapacitityRuleId = "RCR001";
+        internal static readonly LocalizableString Title = "When known, please set the capacity of the dynamic collection";
+        internal static readonly LocalizableString MessageFormat = "'{0}' is a dynamic collection (i.e. a List for instance) and not setting the capacity at the initialization phase of the collection is horrendous for performance when it can be set with {1}.";
+        internal static readonly LocalizableString Description = "The default capacity of dynamic collection is initially set at 0 and becomes 4 at the first insertion. Over time, every time the collection count reaches its capacity limit, an extra allocation must be made and the total capacity is doubled. For big collections, insertions is a constant O(1) operation until it reaches the limited capacity and then it becomes O(n) where n is the total size of the collection.";
+        internal const string Category = "Performance";
+
+        internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(SetCapacitityRuleId, Title, MessageFormat, Category, DiagnosticSeverity.Error, true, Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.MethodDeclaration);
+        }
+
+        private static void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MethodDeclarationSyntax methodDeclaration)
+            {
+            }
+
+        }
+    }
+}

--- a/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation/DynamicCollections/CSharpSetCollectionCapacityAnalyzer.cs
+++ b/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation/DynamicCollections/CSharpSetCollectionCapacityAnalyzer.cs
@@ -36,7 +36,11 @@ namespace Robotmaster.CollectionRecommendation.DynamicCollections
                 var symbolInfo = context.SemanticModel.GetSymbolInfo(localDeclaration.Declaration.Type);
                 if (symbolInfo.Symbol is INamedTypeSymbol namedTypeSymbol && IsADynamicCollection(namedTypeSymbol))
                 {
-                    .ToList();
+                    // No problem if the collection is defined with an initial set of values; the capacity will be set then.
+                    if (IsCollectionDefinedWithInitializer(localDeclaration.Declaration.Variables))
+                    {
+                        return;
+                    }
 
                 foreach (var localDeclaration in localDeclarations)
                 {
@@ -45,7 +49,7 @@ namespace Robotmaster.CollectionRecommendation.DynamicCollections
 
                 bool IsADynamicCollection(INamedTypeSymbol symbol) => symbol.ConstructedFrom.AllInterfaces.Select(x => x.Name).Any(x => string.Equals(x, "IList<T>"));
 
-                        ? typeSymbol.Interfaces.Select(x => x.Name)
+                bool IsCollectionDefinedWithInitializer(IEnumerable<VariableDeclaratorSyntax> declaratorCollection) => declaratorCollection.Any(declarator => (declarator.Initializer.Value as ObjectCreationExpressionSyntax).Initializer.IsKind(SyntaxKind.CollectionInitializerExpression));
             }
         }
     }

--- a/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation.csproj
+++ b/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>

--- a/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation/RobotmasterCollectionRecommendationAnalyzer.cs
+++ b/Robotmaster.CollectionRecommendation/Robotmaster.CollectionRecommendation/RobotmasterCollectionRecommendationAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Robotmaster.CollectionRecommendation
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AnalyzerDescription), Resources.ResourceManager, typeof(Resources));
         private const string Category = "Naming";
 
-        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 


### PR DESCRIPTION
For this analyzer, it's a bit more complicated than we anticipated at the start. There are multiple cases and I don't think it's feasible to try to anticipate most of them during the hackathon week. To that end, here are the following cases checked by the code analyzer: 

- [x] Makes sure to only looked at local variables. Another analyzer could be added for fields/properties and they should share some logic, but that's for later.
- [x] Makes sure to only look at collections that implement the generic interface IList.
- [x] Doesn't warn a developer if the dynamic collection has a collection initializer
- [ ] Simple cases for dynamic collection setup 

1. If a develop repeatedly invokes the Add function member on the data collection, then the analyzer counts the number of invocation and will suggest it as the initial capacity of the collection.
2.  If a hard-coded value is used as a logical condition to exit the for loop and collection is updated within the said loop, the capacity suggested will be this hard-coded value.
3. If a constant is used as a logical condition to exit the for loop and collection is updated within the said loop, the capacity suggested will be the constant.

I think that's a good start for now. To showcase the expected performance gains, this PR will also come with benchmarks for 

- List
- Dictionary
- HashSet