### PR TITLE
fix links in ruleset.md

### DIFF
--- a/ruleset.md
+++ b/ruleset.md
@@ -4,8 +4,8 @@ You can learn more about the rules covered by the repository by diving into the 
 
 ## Performance
 
-See more [here](#documentation/performanceRules.md).
+See more [here](documentation/performanceRules.md).
 
 ## Code Quality
 
-See more [here](#documentation/codeQualityRules.md).
+See more [here](documentation/codeQualityRules.md).


### PR DESCRIPTION
the current links redirects to 
https://github.com/hypertherm/DotNet.SystemCollections.Analyzers/blob/master/ruleset.md#documentation/performanceRules.md

instead of

https://github.com/hypertherm/DotNet.SystemCollections.Analyzers/blob/master/documentation/performanceRules.md